### PR TITLE
fix: support >=py3.10 and run as module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ EXPOSE ${MCP_SSE_PORT} ${MCP_STREAMABLE_HTTP_PORT}
 
 ENV PYTHONUNBUFFERED=1
 
-CMD ["uv", "run", "src/main.py"]
+CMD ["uv", "run", "python", "-m", "zoekt_mcp.main"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This MCP server integrates with Zoekt, a text search engine optimized for code r
 uv sync
 
 # Run the server
-uv run python src/main.py
+uv run python -m zoekt_mcp.main
 ```
 
 ### Using pip
@@ -64,7 +64,7 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -e .
 
 # Run the server
-python src/main.py
+python -m zoekt_mcp.main
 ```
 
 ### Using Docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "zoekt-mcp"
 version = "0.1.0"
 description = "Model Context Protocol (MCP) server for Zoekt code search"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.10,<3.14"
 license = "MIT"
 authors = [
     { name = "Erfan Mirshams", email = "erfan.mirshams@gmail.com" }


### PR DESCRIPTION
I wanted to run this project myself, and stumbled on a couple of errors:

Maturin does not support Python 3.14 yet, so I limited it:

>         error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
>         = help: please check if an updated version of PyO3 is available. Current version: 0.24.1
>         = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI
>       warning: build failed, waiting for other jobs to finish...
>       💥 maturin failed
>         Caused by: Failed to build a native library through cargo

And when I fixed that (I also got python3.10 to run correctly ;-P), I stumbled on this error:

```bash
# uv run python src/main.py
warning: The package `pydantic-ai==1.6.0` does not have an extra named `logfire`
warning: The package `huggingface-hub==1.2.3` does not have an extra named `inference`
Traceback (most recent call last):
  File "/var/local/zoekt-mcp/src/main.py", line 25, in <module>
    from .server import main as search_main
ImportError: attempted relative import with no known parent package
```

That is fixed by simply running it as a python module: `uv run python -m zoekt_mcp.main`

Thanks for the great tool - works great for me using the latest zoekt version + these fixes