### PR TITLE
Make content-size limits configurable via env vars (fetch_content + search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ docker run -p 9000:9000 -p 9080:9080 \
 
 - `MCP_SSE_PORT`: SSE server port (default: 8000)
 - `MCP_STREAMABLE_HTTP_PORT`: HTTP server port (default: 8080)
+- `ZOEKT_MCP_MAX_FILE_SIZE`: Max bytes of file content returned by `fetch_content` before the file is truncated (default: 100000). Raise this if you routinely fetch larger source files.
+- `ZOEKT_MCP_MAX_LINE_LENGTH`: Max characters per match line returned by `search` before the line is truncated (default: 300). Raise this for long lines such as minified JS, generated code, or wide tables.
+- `ZOEKT_MCP_MAX_OUTPUT_LENGTH`: Max total characters of formatted `search` output (default: 100000). Raise this to allow larger aggregate result payloads.
 
 ## Usage with AI Tools
 

--- a/src/backends/client.py
+++ b/src/backends/client.py
@@ -1,20 +1,30 @@
-from typing import List
+import os
+from typing import List, Optional
 
 import requests
 from .models import FormattedResult, Match
 from .search_protocol import SearchClientProtocol
+
+# Defaults can be overridden via environment variables without code changes.
+# Explicit constructor arguments always win over env vars.
+DEFAULT_MAX_LINE_LENGTH = int(os.getenv("ZOEKT_MCP_MAX_LINE_LENGTH", "300"))
+DEFAULT_MAX_OUTPUT_LENGTH = int(os.getenv("ZOEKT_MCP_MAX_OUTPUT_LENGTH", "100000"))
 
 
 class ZoektClient(SearchClientProtocol):
     def __init__(
         self,
         base_url: str,
-        max_line_length: int = 300,
-        max_output_length: int = 100000,
+        max_line_length: Optional[int] = None,
+        max_output_length: Optional[int] = None,
     ):
         self.base_url = base_url.rstrip("/")
-        self.max_line_length = max_line_length
-        self.max_output_length = max_output_length
+        self.max_line_length = (
+            max_line_length if max_line_length is not None else DEFAULT_MAX_LINE_LENGTH
+        )
+        self.max_output_length = (
+            max_output_length if max_output_length is not None else DEFAULT_MAX_OUTPUT_LENGTH
+        )
 
     def search(self, query: str, num: int) -> dict:
         params = {

--- a/src/backends/content_fetcher_protocol.py
+++ b/src/backends/content_fetcher_protocol.py
@@ -1,6 +1,9 @@
+import os
 from typing import Protocol, runtime_checkable
 
-MAX_FILE_SIZE = 100_000
+# Max bytes of file content returned by fetch_content before truncation.
+# Override with the ZOEKT_MCP_MAX_FILE_SIZE environment variable.
+MAX_FILE_SIZE = int(os.getenv("ZOEKT_MCP_MAX_FILE_SIZE", "100000"))
 
 
 @runtime_checkable


### PR DESCRIPTION
## Summary

Adds three environment variables to override the hardcoded content-size limits in `fetch_content` and `search`, without changing any defaults. Fully backward compatible.

| Env var | Overrides | Default |
|---|---|---|
| `ZOEKT_MCP_MAX_FILE_SIZE` | `backends/content_fetcher_protocol.MAX_FILE_SIZE` — `fetch_content` truncation threshold | `100000` |
| `ZOEKT_MCP_MAX_LINE_LENGTH` | `ZoektClient.max_line_length` — per-match-line truncation in `search` | `300` |
| `ZOEKT_MCP_MAX_OUTPUT_LENGTH` | `ZoektClient.max_output_length` — total formatted search output cap | `100000` |

Explicit `ZoektClient(max_line_length=..., max_output_length=...)` constructor arguments still take precedence over env vars.

## Motivation

When using zoekt-mcp against a Zoekt instance indexing larger source files (decompiled C, generated code, large JSON fixtures, minified JS), the hardcoded 100k / 300 / 100k limits force truncation on content that would otherwise fit fine in an LLM context. Patching the source per deployment is awkward when running the published Docker image — env vars let operators tune the limits without rebuilding.

## Changes

- `src/backends/content_fetcher_protocol.py`: `MAX_FILE_SIZE` reads from `ZOEKT_MCP_MAX_FILE_SIZE` with default `100000`.
- `src/backends/client.py`: `ZoektClient.__init__` falls back to `ZOEKT_MCP_MAX_LINE_LENGTH` / `ZOEKT_MCP_MAX_OUTPUT_LENGTH` when the caller passes `None` (i.e., relies on the default). The constructor signature is changed to `Optional[int] = None` rather than literal defaults so env-driven and caller-specified values compose cleanly.
- `README.md`: documents the three new Optional Environment Variables.

## Backward compatibility

- Defaults are identical to previous hardcoded values (`100000` / `300` / `100000`).
- Callers passing explicit ints to `ZoektClient` keep the exact same behavior.
- Only behavioral difference: callers that were passing `None` explicitly (unlikely) will now hit the env-driven default instead of a `TypeError` — the prior signature didn't allow `None`, so this is strictly more permissive.

## Test plan

- [x] With no env vars set → defaults match upstream (`100000 / 300 / 100000`).
- [x] With all three env vars set → overrides take effect.
- [x] With an explicit constructor arg → constructor arg wins over env var.